### PR TITLE
Use browser option UI for settings

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Thumbnail Rating Bar for YouTube™",
 	"version": "0.1.2",
 	"description": "Displays a rating bar (likes/dislikes) on the bottom of every YouTube™ video thumbnail.",
-  "author": "Elliot Waite",
+    "author": "Elliot Waite",
 	"icons": {
 		"96": "icons/icon96.png",
 		"128": "icons/icon128.png"
@@ -18,9 +18,9 @@
 		"browser_style": false
     },
 	"background": {
-    "scripts": ["background.js"],
-    "persistent": false
-  },
+        "scripts": ["background.js"],
+        "persistent": false
+    },
 	"content_scripts": [{
 		"matches": ["*://*.youtube.com/*"],
 		"css": ["content-style.css"],
@@ -30,9 +30,9 @@
 		],
 		"run_at": "document_end"
 	}],
-  "permissions": [
+    "permissions": [
 		"*://*.youtube.com/*",
-    "https://www.googleapis.com/*",
+        "https://www.googleapis.com/*",
 		"storage"
 	]
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -13,6 +13,10 @@
 		"default_title": "Settings",
 		"default_popup": "options-popup.html"
 	},
+	"options_ui": {
+		"page": "options-popup.html",
+		"browser_style": false
+    },
 	"background": {
     "scripts": ["background.js"],
     "persistent": false

--- a/extension/options-style.css
+++ b/extension/options-style.css
@@ -1,5 +1,10 @@
+html {
+  height: auto;
+}
+
 body {
   width: 581px;
+  height: auto;
 }
 
 h5 {


### PR DESCRIPTION
Hello @elliotwaite 
This PR allow the user to interact with the settings also using the UI defined by the browser.
It is useful to me because I can hide the browser_action button (to declutter the bar) while still being able to easily tweak the settings if I feel like to.

It is my opinion that the browser_action key could be removed entirely because it is not semantically correct to use it for settings, but this is very minor issue.

For documentation
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui

Thanks!