### PR TITLE
Add formal support for hiding the rating bar

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -135,6 +135,11 @@ function handleMutations() {
     // them later.
     hasUnseenMutations = true
   } else {
+    // Inject CSS for bars, only if it's shown
+    if (userSettings.barThickness !== 0 && !$('head').find('#ytrb-bar').length) {
+      $('head').append(getRatingBarCssLink())
+    }
+
     // Run the updates.
     updateThumbnailRatingBars()
     updateVideoRatingBarTooltips()
@@ -244,7 +249,9 @@ function updateThumbnailRatingBars() {
 
   if (thumbnailsAndIds.length) {
     addRatingsToCache(thumbnailsAndIds).then(function() {
-      addRatingBars(thumbnailsAndIds)
+      if (userSettings.barThickness !== 0) {
+        addRatingBars(thumbnailsAndIds)
+      }
       if (userSettings.showPercentage) {
         addRatingPercentage(thumbnailsAndIds)
       }
@@ -382,6 +389,16 @@ function getRatingBarHtml(video) {
           : ''
       ) +
       '</ytrb-bar>'
+}
+
+function getRatingBarCssLink() {
+  let path = chrome.runtime.getURL('top-progress-bar.css');
+  return $('<link/>', {
+    rel: 'stylesheet',
+    type: 'text/css',
+    id: 'ytrb-bar',
+    href: path
+  });
 }
 
 function getRatingPercentageHtml(rating) {

--- a/extension/content-style.css
+++ b/extension/content-style.css
@@ -120,25 +120,6 @@ ytg-thumbnail .ytrb-bar {
   z-index: 1;
 }
 
-/* Move the watch history progress bar to the top of the thumbnail. */
-ytd-thumbnail-overlay-resume-playback-renderer,  /* Modern */
-.resume-playback-background,  /* Classic */
-.resume-playback-progress-bar,  /* Classic */
-ytg-thumbnail-overlay-resume-playback-renderer  /* Gaming */
-{
-  top: 0 !important;
-}
-#bottom-thumbnail-overlay-badges  /* Gaming */
-{
-  height: calc(100% - 8px);
-}
-ytg-thumbnail-overlay-time-status-renderer /* Gaming */
-{
-  position: absolute;
-  bottom: 4px;
-  height: 15px;
-}
-
 /* Prevent the video page rating bar tooltip from wrapping to multiple lines. */
 .ytd-sentiment-bar-renderer {
   white-space: nowrap;

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -42,5 +42,8 @@
     "*://*.youtube.com/*",
     "https://www.googleapis.com/*",
     "storage"
+  ],
+  "web_accessible_resources": [
+    "top-progress-bar.css"
   ]
 }

--- a/extension/options-script.js
+++ b/extension/options-script.js
@@ -48,8 +48,8 @@ $('#save-btn').click(function() {
     barColor: $('#bar-color-green-red').prop('checked')
       ? 'green-red'
       : 'blue-gray',
-    barThickness: $('#bar-thickness').val(),
-    barOpacity: $('#bar-opacity').val(),
+    barThickness: Number($('#bar-thickness').val()),
+    barOpacity: Number($('#bar-opacity').val()),
     barSeparator: $('#bar-separator').prop('checked'),
     barTooltip: $('#bar-tooltip').prop('checked'),
     showPercentage: $('#show-percentage').prop('checked'),

--- a/extension/options-script.js
+++ b/extension/options-script.js
@@ -6,7 +6,7 @@ $('#bar-color-blue-gray, #bar-color-green-red').change(function(event) {
 
 // Watch thickness slider.
 $('#bar-thickness').on('input change', function(event) {
-  $('#bar-thickness-text').text($('#bar-thickness').val() + ' px')
+  $('#bar-thickness-text').text($('#bar-thickness').val() === '0' ? 'Hidden' : $('#bar-thickness').val() + ' px')
   $('#thumbnail-preview ytrb-bar, #thumbnail-preview ytrb-rating').height($('#bar-thickness').val() + 'px')
   // A ghetto implementation of making the slider bubble move with the handle.
   $('#bar-thickness-text').css('left', ($('#bar-thickness').val() / 16 * 210) + 'px')

--- a/extension/top-progress-bar.css
+++ b/extension/top-progress-bar.css
@@ -1,0 +1,18 @@
+/* Move the watch history progress bar to the top of the thumbnail. */
+ytd-thumbnail-overlay-resume-playback-renderer,  /* Modern */
+.resume-playback-background,  /* Classic */
+.resume-playback-progress-bar,  /* Classic */
+ytg-thumbnail-overlay-resume-playback-renderer  /* Gaming */
+{
+  top: 0 !important;
+}
+#bottom-thumbnail-overlay-badges  /* Gaming */
+{
+  height: calc(100% - 8px);
+}
+ytg-thumbnail-overlay-time-status-renderer /* Gaming */
+{
+  position: absolute;
+  bottom: 4px;
+  height: 15px;
+}


### PR DESCRIPTION
When the thickness is set to 0 with the rating bar, it'll move the progress bar back to the bottom. I only moved minimal CSS necessary to avoid repaints, though feel free to change it up if you see fit.