### PR TITLE
Fix video rating percentage

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -326,7 +326,11 @@ function addRatingPercentage(thumbnailsAndIds) {
   // Add the rating percentage below each thumbnail.
   for (let [thumbnail, id] of thumbnailsAndIds) {
     if (id in videoCache) {
-      var metadataLine = $(thumbnail).closest('#dismissable').find('#metadata-line').last()
+      let videoContainer = $(thumbnail).closest('#content.style-scope.ytd-rich-item-renderer')
+      if (videoContainer.length === 0) {
+        videoContainer = $(thumbnail).closest('ytd-compact-video-renderer')
+      }
+      let metadataLine = videoContainer?.find('#metadata-line').last()
       if (metadataLine) {
         // Remove any previously added percentages.
         for (let oldPercentage of metadataLine.children('.ytrb-percentage')) {


### PR DESCRIPTION
It looks like YouTube may now be lazy loading #dismissable so the parent element has to be searched for instead. I'm not able to confirm this is only occurring for everyone but this quick edit fixes the issue for me

EDIT: Oops made a typo and I can't seem to undo it cleanly - I'm going to close this pr and make a new one