### PR TITLE
fix: skip thumbnails in chapter expandable or snackbar

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -381,6 +381,14 @@ function removeRatingPercentage(thumbnailElement) {
 async function processThumbnail(thumbnailElement, thumbnailUrl) {
   let splitUrl = thumbnailUrl.split("/")
 
+  // Skip thumbnails inside the chapter expandable panel or snackbar.
+  const isInChapterExpandable = thumbnailElement.closest("ytd-expandable-metadata-renderer") !== null
+  const isInSnackBar =
+    thumbnailElement.closest("snackbar-container") !== null
+  if (isInChapterExpandable || isInSnackBar) {
+    return
+  }
+
   // We don't want to add rating bars to the chapter thumbnails. Chapter
   // thumbnail filenames use the format: "hqdefault_*.jpg", where `*` is an
   // integer that is the number of milliseconds into the video that the


### PR DESCRIPTION
fix #102

I'm not sure if this fix makes the check here redundant so I'm keeping it:

https://github.com/elliotwaite/thumbnail-rating-bar-for-youtube/blob/09afa517370e487794186d79a7f95e0a4ec5ce5a/extension/content-script.js#L384-L396